### PR TITLE
fixes string literals with escaped string terminators

### DIFF
--- a/cfml.dictionary/pom.xml
+++ b/cfml.dictionary/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.cfparser</groupId>
 		<artifactId>cfparser</artifactId>
-		<version>2.2.1</version>
+		<version>2.2.2</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.cfparser</groupId>
 		<artifactId>cfparser</artifactId>
-		<version>2.2.1</version>
+		<version>2.2.2</version>
 	</parent>
 	
 <properties>

--- a/cfml.parsing/src/main/antlr4/cfml/CFSCRIPTLexer.g4
+++ b/cfml.parsing/src/main/antlr4/cfml/CFSCRIPTLexer.g4
@@ -150,7 +150,8 @@ SWITCH: [sS][wW][iI][tT][cC][hH];
 CASE: [cC][aA][sS][eE];
 DEFAULT: [dD][eE][fF][aA][uU][lL][tT];
 FINALLY: [fF][iI][nN][aA][lL][lL][yY];
-SCRIPTCLOSE: '</CFSCRIPT>'; 
+SCRIPTOPEN: '<' [cC] [fF] [sS] [cC] [rR] [iI] [pP] [tT] '>';
+SCRIPTCLOSE:'</' [cC] [fF] [sS] [cC] [rR] [iI] [pP] [tT] '>';
 // operators
 DOT: '.';
 STAR: '*';
@@ -199,6 +200,7 @@ TRANSACTION: [tT][rR][aA][nN][sS][aA][cC][tT][iI][oO][nN];
 // cfmlfunction (tags you can call from script)
 SAVECONTENT: [sS][aA][vV][eE][cC][oO][nN][tT][eE][nN][tT];
 HTTP: [hH][tT][tT][pP][sS]?([:][/][/])?;
+CFHTTP: [cC][fF] HTTP;
 FILE: [fF][iI][lL][eE];
 DIRECTORY: [dD][iI][rR][eE][cC][tT][oO][rR][yY];
 LOOP: [lL][oO][oO][pP]; 
@@ -249,6 +251,7 @@ GRIDUPDATE: [Gg][Rr][Ii][Dd][Uu][Pp][Dd][Aa][Tt][Ee];
 HEADER: [Hh][Ee][Aa][Dd][Ee][Rr];
 HTMLHEAD: [Hh][Tt][Mm][Ll][Hh][Ee][Aa][Dd];
 HTTPPARAM: [Hh][Tt][Tt][Pp][Pp][Aa][Rr][Aa][Mm];
+CFHTTPPARAM: [cC][fF] HTTPPARAM;
 IMPERSONATE: [Ii][Mm][Pp][Ee][Rr][Ss][Oo][Nn][Aa][Tt][Ee];
 INDEX: [Ii][Nn][Dd][Ee][Xx];
 INPUT: [Ii][Nn][Pp][Uu][Tt];
@@ -285,6 +288,7 @@ UPDATE: [Uu][Pp][Dd][Aa][Tt][Ee];
 WDDX: [Ww][Dd][Dd][Xx];
 ZIP: [Zz][Ii][Pp];
 
+CFCUSTOM_IDENTIFIER: [cC][fF]'_' IDENTIFIER+;
 
 IDENTIFIER 
 	:	LETTER (LETTER|CF_DIGIT)*;
@@ -324,7 +328,7 @@ DOUBLEHASH
 	: '##' 
 ;
 STRING_LITERAL
-	: ~["#]+
+	: (~["#]+ | '""' )*
 ;
 HASH
 	: '#' -> type(POUND_SIGN),pushMode(HashMode),pushMode(DefaultMode)
@@ -339,7 +343,7 @@ DOUBLEHASH_SINGLE
 	: '##' -> type(DOUBLEHASH)
 ;
 STRING_LITERAL_SINGLE
-	: ~['#]+ -> type(STRING_LITERAL)
+	: (~['#]+ | '\'\'' )* -> type(STRING_LITERAL)
 ;
 HASH_SINGLE
 	: '#' -> type(POUND_SIGN),pushMode(HashMode),pushMode(DefaultMode)

--- a/cfml.parsing/src/main/antlr4/cfml/CFSCRIPTParser.g4
+++ b/cfml.parsing/src/main/antlr4/cfml/CFSCRIPTParser.g4
@@ -9,10 +9,11 @@ options { tokenVocab=CFSCRIPTLexer; }
 ////--- cfscript grammar rules
 
 scriptBlock
-  : 
+  :
   importStatement*
   componentDeclaration
   | ( element )* endOfScriptBlock
+  | SCRIPTOPEN scriptBlock
   ; 
 
 componentDeclaration
@@ -226,6 +227,7 @@ tagOperatorStatement
   | threadStatement
   | transactionStatement
   | cfmlfunctionStatement
+  | tagFunctionStatement
   ; 
   
 rethrowStatment:
@@ -238,7 +240,7 @@ includeStatement
   ;
 
 importStatement
-  : lc=IMPORT componentPath (DOT all=STAR)? SEMICOLON 
+  : lc=IMPORT componentPath (DOT all=STAR)? SEMICOLON
   ;
 
 transactionStatement
@@ -246,13 +248,16 @@ transactionStatement
   ;
   
 cfmlfunctionStatement
-  : cfmlFunction (paramStatementAttributes)? (compoundStatement | SEMICOLON)//-> ^(CFMLFUNCTIONSTATEMENT cfmlFunction (param)* (compoundStatement)?)
+  : cfmlFunction (paramStatementAttributes)? (compoundStatement | SEMICOLON) //-> ^(CFMLFUNCTIONSTATEMENT cfmlFunction (param)* (compoundStatement)?)
   ;
-  
+
+tagFunctionStatement
+  : cfmlFunction (LEFTPAREN parameterList RIGHTPAREN)? (compoundStatement | SEMICOLON)?
+  ;
+
 cfmlFunction
   : SAVECONTENT
-  | HTTP 
-  | FILE 
+  | FILE
   | PROPERTY
   | DIRECTORY
   | LOOP 
@@ -277,7 +282,10 @@ cfmlFunction
   | GRIDUPDATE
   | HEADER
   | HTMLHEAD
+  | HTTP
+  | CFHTTP
   | HTTPPARAM
+  | CFHTTPPARAM
   | IMPERSONATE
   | INDEX
   | INPUT
@@ -313,6 +321,7 @@ cfmlFunction
   | UPDATE
   | WDDX
   | ZIP
+  | CFCUSTOM_IDENTIFIER
   ;
 
 /*
@@ -413,6 +422,7 @@ compareExpression
 		(operator=compareExpressionOperator right=compareExpression)?
 	) 
 	(QUESTIONMARK ternaryExpression1=startExpression COLON ternaryExpression2=startExpression)?
+
 	;
 	
 compareExpressionOperator:

--- a/cfml.parsing/src/main/java/cfml/parsing/ParseMessage.java
+++ b/cfml.parsing/src/main/java/cfml/parsing/ParseMessage.java
@@ -77,6 +77,9 @@ public class ParseMessage {
 		docEndOffset = docEnd;
 		docData = data;
 		message = msg;
+		if (message == null) {
+			message = data;
+		}
 	}
 	
 	/**
@@ -192,7 +195,6 @@ public class ParseMessage {
 	
 	@Override
 	public String toString() {
-		return "Line: " + lineNumber + " offset:" + docStartOffset + " endoffset:" + docEndOffset + " message:"
-				+ message;
+		return "Line: " + lineNumber + " offset:" + docStartOffset + " endoffset:" + docEndOffset + " message:" + message;
 	}
 }

--- a/cfml.parsing/src/main/java/cfml/parsing/cfscript/CFStringExpression.java
+++ b/cfml.parsing/src/main/java/cfml/parsing/cfscript/CFStringExpression.java
@@ -26,7 +26,9 @@ public class CFStringExpression extends CFExpression {
 		for (CFExpression expression : subExpressions) {
 			if (expression instanceof CFLiteral) {
 				final String txt = expression.Decompile(0);
-				sb.append(txt.substring(1, txt.length() - 1));
+				if (txt != null) {
+					sb.append(txt.substring(1, txt.length() - 1));
+				}
 			} else {
 				sb.append("#");
 				sb.append(expression.Decompile(0));

--- a/cfml.parsing/src/main/java/cfml/parsing/cfscript/walker/CFScriptStatementVisitor.java
+++ b/cfml.parsing/src/main/java/cfml/parsing/cfscript/walker/CFScriptStatementVisitor.java
@@ -167,9 +167,8 @@ public class CFScriptStatementVisitor extends CFSCRIPTParserBaseVisitor<CFScript
 					cfExpressionVisitor.visit(attr.startExpression()));
 		}
 		
-		CFFuncDeclStatement funcDeclStatement = new CFFuncDeclStatement(ctx.FUNCTION().getSymbol(),
-				(CFIdentifier) null, getText(ctx.accessType()), getText(ctx.typeSpec()), parameters, attributes,
-				visit(ctx.body));
+		CFFuncDeclStatement funcDeclStatement = new CFFuncDeclStatement(ctx.FUNCTION().getSymbol(), (CFIdentifier) null,
+				getText(ctx.accessType()), getText(ctx.typeSpec()), parameters, attributes, visit(ctx.body));
 		return funcDeclStatement;
 	}
 	
@@ -178,8 +177,8 @@ public class CFScriptStatementVisitor extends CFSCRIPTParserBaseVisitor<CFScript
 	public CFScriptStatement visitParameter(ParameterContext ctx) {
 		// System.out.println("visitParameter");
 		
-		CFExpression defaultExpr = (ctx.startExpression() != null) ? cfExpressionVisitor.visitStartExpression(ctx
-				.startExpression()) : null;
+		CFExpression defaultExpr = (ctx.startExpression() != null)
+				? cfExpressionVisitor.visitStartExpression(ctx.startExpression()) : null;
 		CFFunctionParameter functionParameter = new CFFunctionParameter(
 				(CFIdentifier) cfExpressionVisitor.visitIdentifier(ctx.identifier()), ctx.REQUIRED() != null,
 				getText(ctx.parameterType()), defaultExpr);
@@ -236,7 +235,8 @@ public class CFScriptStatementVisitor extends CFSCRIPTParserBaseVisitor<CFScript
 				|| ctx.getChild(0) instanceof AssignmentExpressionContext
 				|| ctx.getChild(0) instanceof BaseExpressionContext
 				|| ctx.getChild(0) instanceof CompareExpressionContext) {
-			CFExpressionStatement expressionStmt = new CFExpressionStatement(cfExpressionVisitor.visit(ctx.getChild(0)));
+			CFExpressionStatement expressionStmt = new CFExpressionStatement(
+					cfExpressionVisitor.visit(ctx.getChild(0)));
 			// System.out.println("visitStatement.b" + expressionStmt.Decompile(0));
 			return expressionStmt;
 		}
@@ -246,8 +246,8 @@ public class CFScriptStatementVisitor extends CFSCRIPTParserBaseVisitor<CFScript
 	@Override
 	public CFScriptStatement visitReturnStatement(ReturnStatementContext ctx) {
 		// System.out.println("visitReturnStatement");
-		CFReturnStatement returnStatement = new CFReturnStatement(ctx.getStart(), cfExpressionVisitor.visit(ctx
-				.getChild(1)));
+		CFReturnStatement returnStatement = new CFReturnStatement(ctx.getStart(),
+				cfExpressionVisitor.visit(ctx.getChild(1)));
 		return returnStatement;
 	}
 	
@@ -279,13 +279,15 @@ public class CFScriptStatementVisitor extends CFSCRIPTParserBaseVisitor<CFScript
 	public CFScriptStatement visitForStatement(ForStatementContext ctx) {
 		// System.out.println("visitForStatement");
 		if (ctx.forInKey() != null) {
-			CFForInStatement forInStatement = new CFForInStatement(ctx.FOR().getSymbol(), cfExpressionVisitor.visit(ctx
-					.forInKey()), cfExpressionVisitor.visit(ctx.inExpr), visit(ctx.statement()));
+			CFForInStatement forInStatement = new CFForInStatement(ctx.FOR().getSymbol(),
+					cfExpressionVisitor.visit(ctx.forInKey()), cfExpressionVisitor.visit(ctx.inExpr),
+					visit(ctx.statement()));
 			return forInStatement;
 		} else {
 			CFForStatement forStatement = new CFForStatement(ctx.FOR().getSymbol(),
-					cfExpressionVisitor.visit(ExpressionUtils.coalesce(ctx.localAssignmentExpression(),
-							ctx.initExpression)), cfExpressionVisitor.visit(ctx.condExpression),
+					cfExpressionVisitor
+							.visit(ExpressionUtils.coalesce(ctx.localAssignmentExpression(), ctx.initExpression)),
+					cfExpressionVisitor.visit(ctx.condExpression),
 					cfExpressionVisitor.visit(ExpressionUtils.coalesce(ctx.incrExpression, ctx.incrExpression2)),
 					visit(ctx.statement()));
 			return forStatement;
@@ -512,8 +514,8 @@ public class CFScriptStatementVisitor extends CFSCRIPTParserBaseVisitor<CFScript
 	public CFScriptStatement visitParam(ParamContext ctx) {
 		// System.out.println("visitParam");
 		if (!aggregator.isEmpty() && aggregator.peek() instanceof CFParsedAttributeStatement) {
-			((CFParsedAttributeStatement) aggregator.peek()).getAttributes().put(
-					(CFIdentifier) visitExpression(ctx.identifier()), visitExpression(ctx.startExpression()));
+			((CFParsedAttributeStatement) aggregator.peek()).getAttributes()
+					.put((CFIdentifier) visitExpression(ctx.identifier()), visitExpression(ctx.startExpression()));
 			return null;
 		} else {
 			return super.visitParam(ctx);

--- a/cfml.parsing/src/main/java/cfml/parsing/reporting/ArrayErrorListener.java
+++ b/cfml.parsing/src/main/java/cfml/parsing/reporting/ArrayErrorListener.java
@@ -1,0 +1,42 @@
+package cfml.parsing.reporting;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+
+import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
+
+public class ArrayErrorListener implements ANTLRErrorListener {
+	
+	List<String> errors = new ArrayList<String>();
+	
+	public ArrayErrorListener(List<String> errors) {
+		this.errors = errors;
+	}
+	
+	@Override
+	public void syntaxError(Recognizer<?, ?> recognizer, Object token, int line, int offset, String message,
+			RecognitionException re) {
+		errors.add("SyntaxError: Line" + line + ":" + offset + " " + message);
+	}
+	
+	@Override
+	public void reportContextSensitivity(Parser arg0, DFA arg1, int arg2, int arg3, int arg4, ATNConfigSet arg5) {
+		errors.add("contextSensitivity");
+	}
+	
+	@Override
+	public void reportAttemptingFullContext(Parser arg0, DFA arg1, int arg2, int arg3, BitSet arg4, ATNConfigSet arg5) {
+		errors.add("attemptingFullContext");
+	}
+	
+	@Override
+	public void reportAmbiguity(Parser arg0, DFA arg1, int arg2, int arg3, boolean arg4, BitSet arg5, ATNConfigSet arg6) {
+		errors.add("reportAmbiguity");
+	}
+}

--- a/cfml.parsing/src/test/java/cfml/parsing/TestCFMLFunctionStatement.java
+++ b/cfml.parsing/src/test/java/cfml/parsing/TestCFMLFunctionStatement.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import cfml.parsing.cfscript.script.CFScriptStatement;
@@ -117,19 +116,14 @@ public class TestCFMLFunctionStatement {
 	}
 	
 	@Test
-	@Ignore
 	public void testIncludeWithTemplateStatementFail() {
-		/* need to check if this is valid in OBD/ACF */
 		String script = "include template=\"/ram/#randName#\";";
 		CFScriptStatement scriptStatement = null;
-		try {
-			scriptStatement = parseScript(script);
-			scriptStatement.Decompile(0);
-		} catch (Exception fail) {
-			return;
+		scriptStatement = parseScript(script);
+		scriptStatement.Decompile(0);
+		if (fCfmlParser.getMessages().size() != 1) {
+			fail("error expected");
 		}
-		fail("error expected");
-		
 	}
 	
 	@Test
@@ -146,14 +140,32 @@ public class TestCFMLFunctionStatement {
 	
 	@Test
 	public void testImportStatement() {
-		/* need to check if this is valid in OBD/ACF */
-		String script = "import projectshen.core.*;";
+		/* only valid in Lucee/Railo */
+		String script = "import projectshen.core.*; component {}";
 		CFScriptStatement scriptStatement = null;
 		scriptStatement = parseScript(script);
 		if (fCfmlParser.getMessages().size() > 0) {
 			fail("whoops! " + fCfmlParser.getMessages());
 		}
 		assertNotNull(scriptStatement);
+		/* valid in ACF/Lucee/Railo */
+		script = "component { import projectshen.core.*; }";
+		scriptStatement = null;
+		scriptStatement = parseScript(script);
+		if (fCfmlParser.getMessages().size() > 0) {
+			fail("whoops! " + fCfmlParser.getMessages());
+		}
+		assertNotNull(scriptStatement);
+	}
+	
+	@Test
+	public void testImportStatementFail() {
+		/* need to check if this is valid in OBD/ACF */
+		String script = "import projectshen.core.*";
+		parseScript(script);
+		if (fCfmlParser.getMessages().size() != 1) {
+			fail("whoops! " + fCfmlParser.getMessages());
+		}
 	}
 	
 }

--- a/cfml.parsing/src/test/java/cfml/parsing/TestFiles.java
+++ b/cfml.parsing/src/test/java/cfml/parsing/TestFiles.java
@@ -20,6 +20,7 @@ import org.junit.runners.Parameterized;
 
 import cfml.CFSCRIPTLexer;
 import cfml.CFSCRIPTParser;
+import cfml.parsing.reporting.ArrayErrorListener;
 import cfml.parsing.util.TreeUtils;
 import cfml.parsing.utils.TestUtils;
 
@@ -78,6 +79,7 @@ public class TestFiles {
 		
 		CommonTokenStream tokens = new CommonTokenStream(lexer);
 		final CFSCRIPTParser parser = new CFSCRIPTParser(tokens);
+		parser.addErrorListener(new ArrayErrorListener(errors));
 		
 		CFSCRIPTParser.ScriptBlockContext parseTree = null;
 		parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
@@ -89,7 +91,6 @@ public class TestFiles {
 			parser.getInterpreter().setPredictionMode(PredictionMode.LL);
 			parseTree = parser.scriptBlock(); // STAGE 2
 		}
-		
 		final String actualTree = TreeUtils.printTree(parseTree, parser);
 		if (!errors.isEmpty()) {
 			System.out.println("/*===TOKENS===*/\r\n" + actualTokens + "\r\n");
@@ -108,6 +109,10 @@ public class TestFiles {
 			}
 			assertEquals("Parse trees do not match", expectedTree, actualTree);
 		}
+		if (!errors.isEmpty()) {
+			System.out.println(errors.toString());
+		}
+		assertEquals(true, errors.isEmpty());
 	}
 	
 	private void writeExpectFile(File expectedFile, String actualTokens, String actualTree) throws IOException {

--- a/cfml.parsing/src/test/resources/cfml/ScriptComponent.cfc
+++ b/cfml.parsing/src/test/resources/cfml/ScriptComponent.cfc
@@ -1,5 +1,7 @@
 component output="false" {
 
+	color="##000000";
+
 	string function headSpin(required anything, area="elavator") {
 		var toot = "se5ee6yye67tutuityit69t9imfuihki";
 		return funk;

--- a/cfml.parsing/src/test/resources/cfml/tests/cf11_script_customtags.expected.txt
+++ b/cfml.parsing/src/test/resources/cfml/tests/cf11_script_customtags.expected.txt
@@ -1,7 +1,7 @@
 /*===TOKENS===*/
 LINE_COMMENT             <// cfm file based custom tags
 >
-IDENTIFIER               <Cf_happybirthday>
+CFCUSTOM_IDENTIFIER      <Cf_happybirthday>
 '('                      <(>
 IDENTIFIER               <name>
 '='                      <=>
@@ -20,55 +20,47 @@ CLOSE_STRING             <">
 (scriptBlock
   (element
     (statement
-      (startExpression
-        (compareExpression
-          (baseExpression
-            (unaryExpression
-              (memberExpression
-                (functionCall
-                  (identifierOrReservedWord (identifier Cf_happybirthday))
-                  (
-                  (argumentList
-                    (argument
-                      (identifier name)
-                      =
-                      (startExpression
-                        (compareExpression
-                          (baseExpression
-                            (unaryExpression
-                              (primaryExpression
-                                (literalExpression (stringLiteral " (stringLiteralPart john) "))
-                              )
-                            )
-                          )
-                        )
-                      )
-                    )
-                    ,
-                    (argument
-                      (identifier birthdate)
-                      =
-                      (startExpression
-                        (compareExpression
-                          (baseExpression
-                            (unaryExpression
-                              (primaryExpression
-                                (literalExpression (stringLiteral " (stringLiteralPart December 5, 1987) "))
-                              )
-                            )
-                          )
-                        )
+      (tagOperatorStatement
+        (tagFunctionStatement
+          (cfmlFunction Cf_happybirthday)
+          (
+          (parameterList
+            (parameter
+              (identifier name)
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression
+                    (unaryExpression
+                      (primaryExpression
+                        (literalExpression (stringLiteral " (stringLiteralPart john) "))
                       )
                     )
                   )
+                )
+              )
+            )
+            ,
+            (parameter
+              (identifier birthdate)
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression
+                    (unaryExpression
+                      (primaryExpression
+                        (literalExpression (stringLiteral " (stringLiteralPart December 5, 1987) "))
+                      )
+                    )
                   )
                 )
               )
             )
           )
+          )
+          ;
         )
       )
-      ;
     )
   )
   (endOfScriptBlock <EOF>)

--- a/cfml.parsing/src/test/resources/cfml/tests/cf11_script_tags.cfc
+++ b/cfml.parsing/src/test/resources/cfml/tests/cf11_script_tags.cfc
@@ -1,5 +1,5 @@
     cfhttp(url="www.google.com", method="GET");
-       Cfhttp(URL=http://#CGI.SERVER_NAME#.../target.cfm, method="GET")
+       Cfhttp(URL="http://#CGI.SERVER_NAME#.../target.cfm", method="GET")
        {
              cfhttpparam(type="url", name='emp_name', value="Awdhesh");
              cfhttpparam(type="header", name='myheader', value="My custom header");

--- a/cfml.parsing/src/test/resources/cfml/tests/cf11_script_tags.expected.txt
+++ b/cfml.parsing/src/test/resources/cfml/tests/cf11_script_tags.expected.txt
@@ -1,5 +1,5 @@
 /*===TOKENS===*/
-IDENTIFIER               <cfhttp>
+CFHTTP                   <cfhttp>
 '('                      <(>
 IDENTIFIER               <url>
 '='                      <=>
@@ -14,23 +14,19 @@ STRING_LITERAL           <GET>
 CLOSE_STRING             <">
 ')'                      <)>
 ';'                      <;>
-IDENTIFIER               <Cfhttp>
+CFHTTP                   <Cfhttp>
 '('                      <(>
 IDENTIFIER               <URL>
 '='                      <=>
-HTTP                     <http://>
+OPEN_STRING              <">
+STRING_LITERAL           <http://>
 '#'                      <#>
 IDENTIFIER               <CGI>
 '.'                      <.>
 IDENTIFIER               <SERVER_NAME>
 '#'                      <#>
-'.'                      <.>
-'.'                      <.>
-'.'                      <.>
-'/'                      </>
-IDENTIFIER               <target>
-'.'                      <.>
-IDENTIFIER               <cfm>
+STRING_LITERAL           <.../target.cfm>
+CLOSE_STRING             <">
 ','                      <,>
 IDENTIFIER               <method>
 '='                      <=>
@@ -39,7 +35,7 @@ STRING_LITERAL           <GET>
 CLOSE_STRING             <">
 ')'                      <)>
 '{'                      <{>
-IDENTIFIER               <cfhttpparam>
+CFHTTPPARAM              <cfhttpparam>
 '('                      <(>
 IDENTIFIER               <type>
 '='                      <=>
@@ -60,7 +56,7 @@ STRING_LITERAL           <Awdhesh>
 CLOSE_STRING             <">
 ')'                      <)>
 ';'                      <;>
-IDENTIFIER               <cfhttpparam>
+CFHTTPPARAM              <cfhttpparam>
 '('                      <(>
 IDENTIFIER               <type>
 '='                      <=>
@@ -84,7 +80,7 @@ CLOSE_STRING             <">
 '}'                      <}>
 IDENTIFIER               <Writeoutput>
 '('                      <(>
-IDENTIFIER               <cfhttp>
+CFHTTP                   <cfhttp>
 '.'                      <.>
 IDENTIFIER               <filecontent>
 ')'                      <)>
@@ -93,24 +89,124 @@ IDENTIFIER               <filecontent>
 (scriptBlock
   (element
     (statement
-      (startExpression
-        (compareExpression
-          (baseExpression
-            (unaryExpression
-              (memberExpression
-                (functionCall
-                  (identifierOrReservedWord (identifier cfhttp))
+      (tagOperatorStatement
+        (tagFunctionStatement
+          (cfmlFunction cfhttp)
+          (
+          (parameterList
+            (parameter
+              (identifier url)
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression
+                    (unaryExpression
+                      (primaryExpression
+                        (literalExpression (stringLiteral " (stringLiteralPart www.google.com) "))
+                      )
+                    )
+                  )
+                )
+              )
+            )
+            ,
+            (parameter
+              (identifier method)
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression
+                    (unaryExpression
+                      (primaryExpression
+                        (literalExpression (stringLiteral " (stringLiteralPart GET) "))
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          )
+          ;
+        )
+      )
+    )
+  )
+  (element
+    (statement
+      (tagOperatorStatement
+        (tagFunctionStatement
+          (cfmlFunction Cfhttp)
+          (
+          (parameterList
+            (parameter
+              (identifier URL)
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression
+                    (unaryExpression
+                      (primaryExpression
+                        (literalExpression
+                          (stringLiteral
+                            "
+                            (stringLiteralPart http://)
+                            #
+                            (startExpression
+                              (compareExpression
+                                (baseExpression
+                                  (unaryExpression
+                                    (memberExpression (identifier CGI) . (identifier SERVER_NAME))
+                                  )
+                                )
+                              )
+                            )
+                            #
+                            (stringLiteralPart .../target.cfm)
+                            "
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+            ,
+            (parameter
+              (identifier method)
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression
+                    (unaryExpression
+                      (primaryExpression
+                        (literalExpression (stringLiteral " (stringLiteralPart GET) "))
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          )
+          (compoundStatement
+            {
+            (statement
+              (tagOperatorStatement
+                (tagFunctionStatement
+                  (cfmlFunction cfhttpparam)
                   (
-                  (argumentList
-                    (argument
-                      (identifier url)
+                  (parameterList
+                    (parameter
+                      (identifier type)
                       =
                       (startExpression
                         (compareExpression
                           (baseExpression
                             (unaryExpression
                               (primaryExpression
-                                (literalExpression (stringLiteral " (stringLiteralPart www.google.com) "))
+                                (literalExpression (stringLiteral " (stringLiteralPart url) "))
                               )
                             )
                           )
@@ -118,15 +214,31 @@ IDENTIFIER               <filecontent>
                       )
                     )
                     ,
-                    (argument
-                      (identifier method)
+                    (parameter
+                      (identifier name)
                       =
                       (startExpression
                         (compareExpression
                           (baseExpression
                             (unaryExpression
                               (primaryExpression
-                                (literalExpression (stringLiteral " (stringLiteralPart GET) "))
+                                (literalExpression (stringLiteral ' (stringLiteralPart emp_name) '))
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                    ,
+                    (parameter
+                      (identifier value)
+                      =
+                      (startExpression
+                        (compareExpression
+                          (baseExpression
+                            (unaryExpression
+                              (primaryExpression
+                                (literalExpression (stringLiteral " (stringLiteralPart Awdhesh) "))
                               )
                             )
                           )
@@ -135,216 +247,72 @@ IDENTIFIER               <filecontent>
                     )
                   )
                   )
+                  ;
                 )
               )
             )
-          )
-        )
-      )
-      ;
-    )
-  )
-  (element statement)
-  (element (statement Cfhttp))
-  (element (statement ())
-  (element
-    (statement
-      (assignmentExpression
-        (startExpression
-          (compareExpression
-            (baseExpression (unaryExpression (memberExpression (identifier URL))))
-          )
-        )
-        =
-        (startExpression
-          (compareExpression
-            (baseExpression
-              (unaryExpression (memberExpression (identifier (cfmlFunction http://))))
-            )
-          )
-        )
-      )
-      <missing ';'>
-    )
-  )
-  (element statement)
-  (element (statement #))
-  element
-  (element CGI)
-  (element (statement .))
-  (element SERVER_NAME)
-  (element (statement #))
-  (element (statement .))
-  (element (statement .))
-  (element (statement . /))
-  element
-  (element target)
-  (element (statement .))
-  (element cfm ,)
-  (element
-    (statement
-      (assignmentExpression
-        (startExpression
-          (compareExpression
-            (baseExpression (unaryExpression (memberExpression (identifier method))))
-          )
-        )
-        =
-        (startExpression
-          (compareExpression
-            (baseExpression
-              (unaryExpression
-                (primaryExpression
-                  (literalExpression (stringLiteral " (stringLiteralPart GET) "))
-                )
-                )
-              )
-            )
-          )
-        )
-      )
-      <missing ';'>
-    )
-  )
-  (element
-    (statement
-      (compoundStatement
-        {
-        (statement
-          (startExpression
-            (compareExpression
-              (baseExpression
-                (unaryExpression
-                  (memberExpression
-                    (functionCall
-                      (identifierOrReservedWord (identifier cfhttpparam))
-                      (
-                      (argumentList
-                        (argument
-                          (identifier type)
-                          =
-                          (startExpression
-                            (compareExpression
-                              (baseExpression
-                                (unaryExpression
-                                  (primaryExpression
-                                    (literalExpression (stringLiteral " (stringLiteralPart url) "))
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                        ,
-                        (argument
-                          (identifier name)
-                          =
-                          (startExpression
-                            (compareExpression
-                              (baseExpression
-                                (unaryExpression
-                                  (primaryExpression
-                                    (literalExpression (stringLiteral ' (stringLiteralPart emp_name) '))
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                        ,
-                        (argument
-                          (identifier value)
-                          =
-                          (startExpression
-                            (compareExpression
-                              (baseExpression
-                                (unaryExpression
-                                  (primaryExpression
-                                    (literalExpression (stringLiteral " (stringLiteralPart Awdhesh) "))
-                                  )
-                                )
+            (statement
+              (tagOperatorStatement
+                (tagFunctionStatement
+                  (cfmlFunction cfhttpparam)
+                  (
+                  (parameterList
+                    (parameter
+                      (identifier type)
+                      =
+                      (startExpression
+                        (compareExpression
+                          (baseExpression
+                            (unaryExpression
+                              (primaryExpression
+                                (literalExpression (stringLiteral " (stringLiteralPart header) "))
                               )
                             )
                           )
                         )
                       )
+                    )
+                    ,
+                    (parameter
+                      (identifier name)
+                      =
+                      (startExpression
+                        (compareExpression
+                          (baseExpression
+                            (unaryExpression
+                              (primaryExpression
+                                (literalExpression (stringLiteral ' (stringLiteralPart myheader) '))
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                    ,
+                    (parameter
+                      (identifier value)
+                      =
+                      (startExpression
+                        (compareExpression
+                          (baseExpression
+                            (unaryExpression
+                              (primaryExpression
+                                (literalExpression (stringLiteral " (stringLiteralPart My custom header) "))
+                              )
+                            )
+                          )
+                        )
                       )
                     )
                   )
-                )
-              )
-            )
-          )
-          ;
-        )
-        (statement
-          (startExpression
-            (compareExpression
-              (baseExpression
-                (unaryExpression
-                  (memberExpression
-                    (functionCall
-                      (identifierOrReservedWord (identifier cfhttpparam))
-                      (
-                      (argumentList
-                        (argument
-                          (identifier type)
-                          =
-                          (startExpression
-                            (compareExpression
-                              (baseExpression
-                                (unaryExpression
-                                  (primaryExpression
-                                    (literalExpression (stringLiteral " (stringLiteralPart header) "))
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                        ,
-                        (argument
-                          (identifier name)
-                          =
-                          (startExpression
-                            (compareExpression
-                              (baseExpression
-                                (unaryExpression
-                                  (primaryExpression
-                                    (literalExpression (stringLiteral ' (stringLiteralPart myheader) '))
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                        ,
-                        (argument
-                          (identifier value)
-                          =
-                          (startExpression
-                            (compareExpression
-                              (baseExpression
-                                (unaryExpression
-                                  (primaryExpression
-                                    (literalExpression (stringLiteral " (stringLiteralPart My custom header) "))
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                      )
-                      )
-                    )
                   )
+                  ;
                 )
               )
             )
+            }
           )
-          ;
         )
-        }
       )
     )
   )
@@ -364,7 +332,11 @@ IDENTIFIER               <filecontent>
                         (compareExpression
                           (baseExpression
                             (unaryExpression
-                              (memberExpression (identifier cfhttp) . (identifier filecontent))
+                              (memberExpression
+                                (identifier (cfmlFunction cfhttp))
+                                .
+                                (identifier filecontent)
+                              )
                             )
                           )
                         )

--- a/cfml.parsing/src/test/resources/cfml/tests/expressions/doubleHashComponent.cfc
+++ b/cfml.parsing/src/test/resources/cfml/tests/expressions/doubleHashComponent.cfc
@@ -1,0 +1,3 @@
+component target="blank" {
+ color="##000000";
+}

--- a/cfml.parsing/src/test/resources/cfml/tests/expressions/doubleHashComponent.expected.txt
+++ b/cfml.parsing/src/test/resources/cfml/tests/expressions/doubleHashComponent.expected.txt
@@ -1,0 +1,68 @@
+/*===TOKENS===*/
+COMPONENT                <component>
+IDENTIFIER               <target>
+'='                      <=>
+OPEN_STRING              <">
+STRING_LITERAL           <blank>
+CLOSE_STRING             <">
+'{'                      <{>
+IDENTIFIER               <color>
+'='                      <=>
+OPEN_STRING              <">
+DOUBLEHASH               <##>
+STRING_LITERAL           <000000>
+CLOSE_STRING             <">
+';'                      <;>
+'}'                      <}>
+/*===TREE===*/
+(scriptBlock
+  (componentDeclaration
+    component
+    (componentAttribute
+      (identifier target)
+      =
+      (startExpression
+        (compareExpression
+          (baseExpression
+            (unaryExpression
+              (primaryExpression
+                (literalExpression (stringLiteral " (stringLiteralPart blank) "))
+              )
+            )
+          )
+        )
+      )
+    )
+    (componentGuts
+      {
+      (element
+        (statement
+          (assignmentExpression
+            (startExpression
+              (compareExpression
+                (baseExpression (unaryExpression (memberExpression (identifier color))))
+              )
+            )
+            =
+            (startExpression
+              (compareExpression
+                (baseExpression
+                  (unaryExpression
+                    (primaryExpression
+                      (literalExpression
+                        (stringLiteral " (stringLiteralPart ##) (stringLiteralPart 000000) ")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          ;
+        )
+      )
+      }
+    )
+  )
+)
+/*======*/

--- a/cfml.parsing/src/test/resources/cfml/tests/expressions/mixedHashAndQuoteEscaped.cfc
+++ b/cfml.parsing/src/test/resources/cfml/tests/expressions/mixedHashAndQuoteEscaped.cfc
@@ -1,0 +1,1 @@
+filename = "#dateformat( Now(), "YY_MM_DD" )#_#TimeFormat( Now(), "HH_mm" )#_Company""stuff"".xls";

--- a/cfml.parsing/src/test/resources/cfml/tests/expressions/mixedHashAndQuoteEscaped.expected.txt
+++ b/cfml.parsing/src/test/resources/cfml/tests/expressions/mixedHashAndQuoteEscaped.expected.txt
@@ -1,0 +1,160 @@
+/*===TOKENS===*/
+IDENTIFIER               <filename>
+'='                      <=>
+OPEN_STRING              <">
+'#'                      <#>
+IDENTIFIER               <dateformat>
+'('                      <(>
+IDENTIFIER               <Now>
+'('                      <(>
+')'                      <)>
+','                      <,>
+OPEN_STRING              <">
+STRING_LITERAL           <YY_MM_DD>
+CLOSE_STRING             <">
+')'                      <)>
+'#'                      <#>
+STRING_LITERAL           <_>
+'#'                      <#>
+IDENTIFIER               <TimeFormat>
+'('                      <(>
+IDENTIFIER               <Now>
+'('                      <(>
+')'                      <)>
+','                      <,>
+OPEN_STRING              <">
+STRING_LITERAL           <HH_mm>
+CLOSE_STRING             <">
+')'                      <)>
+'#'                      <#>
+STRING_LITERAL           <_Company""stuff"".xls>
+CLOSE_STRING             <">
+';'                      <;>
+/*===TREE===*/
+(scriptBlock
+  (element
+    (statement
+      (assignmentExpression
+        (startExpression
+          (compareExpression
+            (baseExpression (unaryExpression (memberExpression (identifier filename))))
+          )
+        )
+        =
+        (startExpression
+          (compareExpression
+            (baseExpression
+              (unaryExpression
+                (primaryExpression
+                  (literalExpression
+                    (stringLiteral
+                      "
+                      #
+                      (startExpression
+                        (compareExpression
+                          (baseExpression
+                            (unaryExpression
+                              (memberExpression
+                                (functionCall
+                                  (identifierOrReservedWord (identifier dateformat))
+                                  (
+                                  (argumentList
+                                    (argument
+                                      (startExpression
+                                        (compareExpression
+                                          (baseExpression
+                                            (unaryExpression
+                                              (memberExpression
+                                                (functionCall (identifierOrReservedWord (identifier Now)) ( argumentList ))
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                    ,
+                                    (argument
+                                      (startExpression
+                                        (compareExpression
+                                          (baseExpression
+                                            (unaryExpression
+                                              (primaryExpression
+                                                (literalExpression (stringLiteral " (stringLiteralPart YY_MM_DD) "))
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                      #
+                      (stringLiteralPart _)
+                      #
+                      (startExpression
+                        (compareExpression
+                          (baseExpression
+                            (unaryExpression
+                              (memberExpression
+                                (functionCall
+                                  (identifierOrReservedWord (identifier TimeFormat))
+                                  (
+                                  (argumentList
+                                    (argument
+                                      (startExpression
+                                        (compareExpression
+                                          (baseExpression
+                                            (unaryExpression
+                                              (memberExpression
+                                                (functionCall (identifierOrReservedWord (identifier Now)) ( argumentList ))
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                    ,
+                                    (argument
+                                      (startExpression
+                                        (compareExpression
+                                          (baseExpression
+                                            (unaryExpression
+                                              (primaryExpression
+                                                (literalExpression (stringLiteral " (stringLiteralPart HH_mm) "))
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
+                                  )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                      #
+                      (stringLiteralPart _Company""stuff"".xls)
+                      "
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+      ;
+    )
+  )
+  (endOfScriptBlock <EOF>)
+)
+/*======*/

--- a/cfml.parsing/src/test/resources/cfml/tests/rail_script_tags.cfc
+++ b/cfml.parsing/src/test/resources/cfml/tests/rail_script_tags.cfc
@@ -15,6 +15,7 @@ Check out the code samples here! You can write tags in CFScript
 Mark
 ");
 }
+directory name="dir" directory=dir action="list";
 //Query a database
 query name="getUsers" dataSource="myDatasource"{
 echo("SELECT * FROM tusers WHERE UserID =");

--- a/cfml.parsing/src/test/resources/cfml/tests/rail_script_tags.expected.txt
+++ b/cfml.parsing/src/test/resources/cfml/tests/rail_script_tags.expected.txt
@@ -146,6 +146,21 @@ CLOSE_STRING             <">
 ')'                      <)>
 ';'                      <;>
 '}'                      <}>
+DIRECTORY                <directory>
+IDENTIFIER               <name>
+'='                      <=>
+OPEN_STRING              <">
+STRING_LITERAL           <dir>
+CLOSE_STRING             <">
+DIRECTORY                <directory>
+'='                      <=>
+IDENTIFIER               <dir>
+IDENTIFIER               <action>
+'='                      <=>
+OPEN_STRING              <">
+STRING_LITERAL           <list>
+CLOSE_STRING             <">
+';'                      <;>
 LINE_COMMENT             <//Query a database
 >
 QUERY                    <query>
@@ -651,6 +666,57 @@ IDENTIFIER               <getUsers>
             )
             }
           )
+        )
+      )
+    )
+  )
+  (element
+    (statement
+      (tagOperatorStatement
+        (cfmlfunctionStatement
+          (cfmlFunction directory)
+          (paramStatementAttributes
+            (param
+              (identifier name)
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression
+                    (unaryExpression
+                      (primaryExpression
+                        (literalExpression (stringLiteral " (stringLiteralPart dir) "))
+                      )
+                    )
+                  )
+                )
+              )
+            )
+            (param
+              (identifier (cfmlFunction directory))
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression (unaryExpression (memberExpression (identifier dir))))
+                )
+              )
+            )
+            (param
+              (identifier action)
+              =
+              (startExpression
+                (compareExpression
+                  (baseExpression
+                    (unaryExpression
+                      (primaryExpression
+                        (literalExpression (stringLiteral " (stringLiteralPart list) "))
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          ;
         )
       )
     )

--- a/cfml.parsing/src/test/resources/cfml/tests/struct_key_plusplus_operator.expected.txt
+++ b/cfml.parsing/src/test/resources/cfml/tests/struct_key_plusplus_operator.expected.txt
@@ -1,7 +1,5 @@
 /*===TOKENS===*/
-LT                       <<>
-IDENTIFIER               <cfscript>
-GT                       <>>
+SCRIPTOPEN               <<cfscript>>
 IDENTIFIER               <foo>
 '='                      <=>
 '{'                      <{>
@@ -15,72 +13,61 @@ IDENTIFIER               <foo>
 IDENTIFIER               <bar>
 '++'                     <++>
 ';'                      <;>
-LT                       <<>
-'/'                      </>
-IDENTIFIER               <cfscript>
-GT                       <>>
+SCRIPTCLOSE              <</cfscript>>
 /*===TREE===*/
 (scriptBlock
-  (element statement)
-  (element (statement <))
-  (element
-    (statement
-      (assignmentExpression
-        (startExpression
-          (compareExpression
-            (baseExpression (unaryExpression (memberExpression (identifier cfscript))))
-            (compareExpressionOperator >)
+  <cfscript>
+  (scriptBlock
+    (element
+      (statement
+        (assignmentExpression
+          (startExpression
             (compareExpression
               (baseExpression (unaryExpression (memberExpression (identifier foo))))
             )
           )
-        )
-        =
-        (startExpression
-          (compareExpression
-            (baseExpression
-              (unaryExpression
-                (primaryExpression
-                  (implicitStruct
-                    {
-                    (implicitStructElements
-                      (implicitStructExpression
-                        (implicitStructKeyExpression (multipartIdentifier (identifier bar)))
-                        :
-                        (baseExpression (unaryExpression (primaryExpression (literalExpression 1))))
+          =
+          (startExpression
+            (compareExpression
+              (baseExpression
+                (unaryExpression
+                  (primaryExpression
+                    (implicitStruct
+                      {
+                      (implicitStructElements
+                        (implicitStructExpression
+                          (implicitStructKeyExpression (multipartIdentifier (identifier bar)))
+                          :
+                          (baseExpression (unaryExpression (primaryExpression (literalExpression 1))))
+                        )
                       )
+                      }
                     )
-                    }
                   )
                 )
               )
             )
           )
         )
+        ;
       )
-      ;
     )
-  )
-  (element
-    (statement
-      (startExpression
-        (compareExpression
-          (baseExpression
-            (unaryExpression
-              (unaryExpression (memberExpression (identifier foo) . (identifier bar)))
-              ++
+    (element
+      (statement
+        (startExpression
+          (compareExpression
+            (baseExpression
+              (unaryExpression
+                (unaryExpression (memberExpression (identifier foo) . (identifier bar)))
+                ++
+              )
             )
           )
         )
+        ;
       )
-      ;
     )
+    (endOfScriptBlock </cfscript>)
   )
-  (element statement)
-  (element (statement < /))
-  (element statement)
-  (element (statement cfscript))
-  (element (statement >))
-  (endOfScriptBlock <EOF>)
 )
 /*======*/

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.cfparser</groupId>
 	<artifactId>cfparser</artifactId>
-	<version>2.2.1</version>
+	<version>2.2.2</version>
 	<packaging>pom</packaging>
 
 	<name>coldfusion-parser</name>


### PR DESCRIPTION
also tweaks tag-as-script tokens, and tightens up tests by checking for parse errors-- should address #29