### PR TITLE
POM dependency cleanup

### DIFF
--- a/cfml.dictionary/pom.xml
+++ b/cfml.dictionary/pom.xml
@@ -22,11 +22,13 @@
 			<artifactId>jericho-html</artifactId>
 			<version>3.4</version>
 		</dependency>
+
+		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
+			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/cfml.dictionary/pom.xml
+++ b/cfml.dictionary/pom.xml
@@ -20,7 +20,6 @@
 		<dependency>
 			<groupId>net.htmlparser.jericho</groupId>
 			<artifactId>jericho-html</artifactId>
-			<version>3.4</version>
 		</dependency>
 
 		<!-- Test Dependencies -->

--- a/cfml.dictionary/pom.xml
+++ b/cfml.dictionary/pom.xml
@@ -29,17 +29,4 @@
 		</dependency>
 
 	</dependencies>
-	<build>
-	<plugins>
-		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-compiler-plugin</artifactId>
-			<version>3.0</version>
-			<configuration>
-				<source>1.7</source>
-				<target>1.7</target>
-			</configuration>
-		</plugin>
-	</plugins>
-</build>
 </project>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -109,15 +109,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-           <source>1.7</source>
-           <target>1.7</target>
-       </configuration>
-	   </plugin>
 	   <plugin>
 		   	<groupId>org.apache.maven.plugins</groupId>
 		   	<artifactId>maven-surefire-plugin</artifactId>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -10,8 +10,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>cfml.parsing</artifactId>
 	<packaging>jar</packaging>
-	
+
 	<properties>
+		<antlr.version>4.7</antlr.version>
+		<slf4j.version>1.7.21</slf4j.version>
+
 		<antlr4.visitor>true</antlr4.visitor>
 		<antlr4.listener>true</antlr4.listener>
 	</properties>
@@ -36,7 +39,7 @@
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4</artifactId>
-			<version>4.7</version>
+			<version>${antlr.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>javolution</groupId>
@@ -46,12 +49,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.21</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
     		<groupId>org.slf4j</groupId>
     		<artifactId>slf4j-simple</artifactId>
-    		<version>1.7.21</version>
+    		<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>
@@ -78,7 +81,7 @@
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>
-				<version>4.7</version>
+				<version>${antlr.version}</version>
 				<executions>
 					<execution>
 						<id>run antlr4</id>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -32,14 +32,11 @@
 			<groupId>org.antlr</groupId>
 			<artifactId>stringtemplate</artifactId>
 			<version>4.0.2</version>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4</artifactId>
 			<version>4.7</version>
-			<type>jar</type>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>javolution</groupId>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -32,11 +32,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
-			<artifactId>stringtemplate</artifactId>
-			<version>4.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
 			<artifactId>antlr4</artifactId>
 			<version>${antlr.version}</version>
 		</dependency>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -29,7 +29,6 @@
 		<dependency>
 			<groupId>net.htmlparser.jericho</groupId>
 			<artifactId>jericho-html</artifactId>
-			<version>3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -66,10 +66,13 @@
 			<artifactId>commons-logging</artifactId>
 			<version>1.2</version>
 		</dependency>
+
+		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,16 @@
 		<maven.compiler.target>1.7</maven.compiler.target>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>net.htmlparser.jericho</groupId>
+				<artifactId>jericho-html</artifactId>
+				<version>3.4</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<profiles>
 		<profile>
 			<id>deploy</id>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 	</properties>
 
 	<profiles>


### PR DESCRIPTION
A bit of cleaning of the POMs. Removing obsolete declarations (because they contain default values), correcting scopes for jUnit, moving versions to `<properties>` or to parent `<dependencyManagement>` to make keeping consistency easier.

One (possibly) important change is the removal of explicit dependency on `org.antlr:stringtemplate` because it's already included as a dependency of `org.antlr:antl4` -- one that I hope is always compatible and tested with that version.

All tests pass green after the changes.