### PR TITLE
Lighten ANTLR dependencies

### DIFF
--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -32,8 +32,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
-			<artifactId>antlr4</artifactId>
+			<artifactId>antlr4-runtime</artifactId>
 			<version>${antlr.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr-runtime</artifactId>
+			<version>3.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>javolution</groupId>
@@ -62,6 +67,12 @@
 		</dependency>
 
 		<!-- Test Dependencies -->
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr4</artifactId>
+			<version>${antlr.version}</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -79,7 +79,6 @@
 				<executions>
 					<execution>
 						<id>run antlr4</id>
-						<phase>generate-sources</phase>
 						<goals>
 							<goal>antlr4</goal>
 						</goals>


### PR DESCRIPTION
Removing the full `antlr4` dependency and replacing it with much lighter `antlr4-runtime` and `antlr-runtime` -- the latter required by some classes in the `cfml.parsing.antlr` package.

Some test classes depend on classes in the `antlr4` package, so I added that one to the `test` scope, but it won't be added to the final package.