### PR TITLE
Develop

### DIFF
--- a/cfml.dictionary/.classpath
+++ b/cfml.dictionary/.classpath
@@ -28,7 +28,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/cfml.dictionary/pom.xml
+++ b/cfml.dictionary/pom.xml
@@ -1,15 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<parent>
-		<groupId>com.github.cfparser</groupId>
-		<artifactId>cfparser</artifactId>
-		<version>2.4.9</version>
-	</parent>
-
 	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.github.cfparser</groupId>
 	<artifactId>cfml.dictionary</artifactId>
 	<packaging>jar</packaging>
+	<version>2.4.9</version>
 
 	<dependencies>
 		<dependency>
@@ -17,11 +13,6 @@
 		    <artifactId>jdom</artifactId>
 		    <version>1.1.3</version>
 		</dependency>
-		<dependency>
-			<groupId>net.htmlparser.jericho</groupId>
-			<artifactId>jericho-html</artifactId>
-		</dependency>
-
 		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/cfml.dictionary/pom.xml
+++ b/cfml.dictionary/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.cfparser</groupId>
 		<artifactId>cfparser</artifactId>
-		<version>2.4.6</version>
+		<version>2.4.9</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/cfml.parsing/.classpath
+++ b/cfml.parsing/.classpath
@@ -24,14 +24,14 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="target/generated-sources/antlr4">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
 		<attributes>
-			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="src" output="target/classes" path="target/generated-sources/antlr4">
 		<attributes>
+			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -22,10 +22,10 @@
 
 	<dependencies>
 		<dependency>
-      	    <groupId>${project.groupId}</groupId>
-        	<artifactId>cfml.dictionary</artifactId>
-        	<version>${cfml.dictionary.version}</version>
-        </dependency>
+	  		<groupId>${project.groupId}</groupId>
+			<artifactId>cfml.dictionary</artifactId>
+			<version>${cfml.dictionary.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>net.htmlparser.jericho</groupId>
@@ -47,9 +47,9 @@
 			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
-    		<groupId>org.slf4j</groupId>
-    		<artifactId>slf4j-simple</artifactId>
-    		<version>${slf4j.version}</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
 		</dependency>
 
 		<!-- Test Dependencies -->
@@ -60,8 +60,9 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	
 	<build>
-	    <plugins>
+		<plugins>
 			<!-- Antlr sources -->
 			<plugin>
 				<groupId>org.antlr</groupId>
@@ -97,49 +98,70 @@
 					</execution>
 				</executions>
 			</plugin>
-	   <plugin>
-		   	<groupId>org.apache.maven.plugins</groupId>
-		   	<artifactId>maven-surefire-plugin</artifactId>
-		   	<version>2.18.1</version>
-		   	<configuration>
-		   		<forkCount>1</forkCount>
-		   		<reuseForks>true</reuseForks>
-		   		<argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
-	   	</configuration>
-			  </plugin>
+			<plugin>
+			  <groupId>pl.project13.maven</groupId>
+			  <artifactId>git-commit-id-plugin</artifactId>
+			  <version>2.2.2</version>
+			  <executions>
+				  <execution>
+					  <phase>validate</phase>
+					  <goals>
+						  <goal>revision</goal>
+					  </goals>
+				  </execution>
+			  </executions>
+			  <configuration>
+				<dateFormat>yyyyMMdd-HHmmss</dateFormat>
+				<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+				<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+				<generateGitPropertiesFile>true</generateGitPropertiesFile>
+				<failOnNoGitDirectory>false</failOnNoGitDirectory>
+				<failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+			  </configuration>
+		  	</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.18.1</version>
+				<configuration>
+					<forkCount>1</forkCount>
+					<reuseForks>true</reuseForks>
+					<argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
+				</configuration>
+			</plugin>
 		</plugins>
-	    <pluginManagement>
-	    	<plugins>
-	    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-	    		<plugin>
-	    			<groupId>org.eclipse.m2e</groupId>
-	    			<artifactId>lifecycle-mapping</artifactId>
-	    			<version>1.0.0</version>
-	    			<configuration>
-	    				<lifecycleMappingMetadata>
-	    					<pluginExecutions>
-	    						<pluginExecution>
-	    							<pluginExecutionFilter>
-	    								<groupId>org.antlr</groupId>
-	    								<artifactId>
-	    									antlr4-maven-plugin
-	    								</artifactId>
-	    								<versionRange>
-	    									[4.7,)
-	    								</versionRange>
-	    								<goals>
-	    									<goal>antlr4</goal>
-	    								</goals>
-	    							</pluginExecutionFilter>
-	    							<action>
-	    								<ignore></ignore>
-	    							</action>
-	    						</pluginExecution>
-	    					</pluginExecutions>
-	    				</lifecycleMappingMetadata>
-	    			</configuration>
-	    		</plugin>
-	    	</plugins>
-	    </pluginManagement>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.antlr</groupId>
+										<artifactId>
+											antlr4-maven-plugin
+										</artifactId>
+										<versionRange>
+											[4.7,)
+										</versionRange>
+										<goals>
+											<goal>antlr4</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.cfparser</groupId>
 		<artifactId>cfparser</artifactId>
-		<version>2.4.9</version>
+		<version>2.4.10-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -12,6 +12,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
+		<cfml.dictionary.version>2.4.6</cfml.dictionary.version>
 		<antlr.version>4.7</antlr.version>
 		<slf4j.version>1.7.21</slf4j.version>
 
@@ -23,7 +24,7 @@
 		<dependency>
       	    <groupId>${project.groupId}</groupId>
         	<artifactId>cfml.dictionary</artifactId>
-        	<version>${project.version}</version>
+        	<version>${cfml.dictionary.version}</version>
         </dependency>
 
 		<dependency>
@@ -32,13 +33,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-runtime</artifactId>
+			<artifactId>antlr4</artifactId>
 			<version>${antlr.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr-runtime</artifactId>
-			<version>3.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>javolution</groupId>
@@ -55,24 +51,8 @@
     		<artifactId>slf4j-simple</artifactId>
     		<version>${slf4j.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>1.2</version>
-		</dependency>
 
 		<!-- Test Dependencies -->
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4</artifactId>
-			<version>${antlr.version}</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -90,6 +70,7 @@
 				<executions>
 					<execution>
 						<id>run antlr4</id>
+						<phase>generate-sources</phase>
 						<goals>
 							<goal>antlr4</goal>
 						</goals>

--- a/cfml.parsing/pom.xml
+++ b/cfml.parsing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.cfparser</groupId>
 		<artifactId>cfparser</artifactId>
-		<version>2.4.6</version>
+		<version>2.4.9</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -32,8 +32,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
-			<artifactId>antlr4</artifactId>
+			<artifactId>antlr4-runtime</artifactId>
 			<version>${antlr.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr-runtime</artifactId>
+			<version>3.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>javolution</groupId>
@@ -63,6 +68,12 @@
 
 		<!-- Test Dependencies -->
 		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr4</artifactId>
+			<version>${antlr.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
@@ -79,7 +90,6 @@
 				<executions>
 					<execution>
 						<id>run antlr4</id>
-						<phase>generate-sources</phase>
 						<goals>
 							<goal>antlr4</goal>
 						</goals>
@@ -117,5 +127,38 @@
 	   	</configuration>
 			  </plugin>
 		</plugins>
+	    <pluginManagement>
+	    	<plugins>
+	    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+	    		<plugin>
+	    			<groupId>org.eclipse.m2e</groupId>
+	    			<artifactId>lifecycle-mapping</artifactId>
+	    			<version>1.0.0</version>
+	    			<configuration>
+	    				<lifecycleMappingMetadata>
+	    					<pluginExecutions>
+	    						<pluginExecution>
+	    							<pluginExecutionFilter>
+	    								<groupId>org.antlr</groupId>
+	    								<artifactId>
+	    									antlr4-maven-plugin
+	    								</artifactId>
+	    								<versionRange>
+	    									[4.7,)
+	    								</versionRange>
+	    								<goals>
+	    									<goal>antlr4</goal>
+	    								</goals>
+	    							</pluginExecutionFilter>
+	    							<action>
+	    								<ignore></ignore>
+	    							</action>
+	    						</pluginExecution>
+	    					</pluginExecutions>
+	    				</lifecycleMappingMetadata>
+	    			</configuration>
+	    		</plugin>
+	    	</plugins>
+	    </pluginManagement>
 	</build>
 </project>

--- a/cfml.parsing/src/main/java/cfml/parsing/cfmentat/tag/CFMLTags.java
+++ b/cfml.parsing/src/main/java/cfml/parsing/cfmentat/tag/CFMLTags.java
@@ -28,6 +28,7 @@ public class CFMLTags {
 	public static final StartTagType CFML_RETURN = StartTagTypeCfReturn.INSTANCE;
 	public static final StartTagType CFML_MAIL = StartTagTypeCFMail.INSTANCE;
 	public static final StartTagType CFML_QUERY = StartTagTypeCFQuery.INSTANCE;
+	public static final StartTagType CFML_QUERYPARAM = StartTagTypeCFQueryParam.INSTANCE;
 	
 	private CFMLTags() {
 	}

--- a/cfml.parsing/src/main/java/cfml/parsing/cfmentat/tag/StartTagTypeCFQueryParam.java
+++ b/cfml.parsing/src/main/java/cfml/parsing/cfmentat/tag/StartTagTypeCFQueryParam.java
@@ -1,0 +1,27 @@
+package cfml.parsing.cfmentat.tag;
+
+import net.htmlparser.jericho.EndTagType;
+import net.htmlparser.jericho.Source;
+import net.htmlparser.jericho.StartTag;
+import net.htmlparser.jericho.StartTagTypeGenericImplementation;
+import net.htmlparser.jericho.Tag;
+
+final class StartTagTypeCFQueryParam extends StartTagTypeGenericImplementation {
+	protected static final StartTagTypeCFQueryParam INSTANCE = new StartTagTypeCFQueryParam();
+	
+	private StartTagTypeCFQueryParam() {
+		super("CFML query param", "<cfqueryparam", ">", EndTagType.NORMAL, true, true, true);
+	}
+	
+	@Override
+	protected Tag constructTagAt(final Source source, final int pos) {
+		final StartTag startTag = (StartTag) super.constructTagAt(source, pos);
+		if (startTag == null)
+			return null;
+		// A CFML script element requires the attribute language="php".
+		// if
+		// (!"php".equalsIgnoreCase(startTag.getAttributes().getValue("language")))
+		// return null;
+		return startTag;
+	}
+}

--- a/cfml.parsing/src/test/java/cfml/parsing/TestFiles.java
+++ b/cfml.parsing/src/test/java/cfml/parsing/TestFiles.java
@@ -32,7 +32,7 @@ import cfml.parsing.util.TreeUtils;
 import cfml.parsing.utils.TestUtils;
 
 /**
- * Run a test over each *.rpgle file in src/test/resources/org/rpgleparser/tests
+ * Run a test over each *.cfc / *.cfm file in src/test/resources/cfml/tests
  * 
  * @author ryaneberly
  * 

--- a/cfml.parsing/src/test/java/cfml/parsing/TestTagFiles.java
+++ b/cfml.parsing/src/test/java/cfml/parsing/TestTagFiles.java
@@ -50,8 +50,6 @@ public class TestTagFiles {
 			singleTestName = ResourceBundle.getBundle("cfml.test").getString("RunSingleTest");
 		} catch (Exception e) {
 		}
-		// init log4j
-		org.apache.log4j.BasicConfigurator.configure();
 	}
 	
 	public TestTagFiles(File sourceFile) {

--- a/cfml.parsing/src/test/resources/tag/tests/parsing/cfqueryparam.cfm
+++ b/cfml.parsing/src/test/resources/tag/tests/parsing/cfqueryparam.cfm
@@ -1,0 +1,3 @@
+<cfquery>
+	select <cfqueryparam> from table where <cfqueryparam> =<cfqueryparam>
+</cfquery>

--- a/cfml.parsing/src/test/resources/tag/tests/parsing/cfqueryparam.expected.txt
+++ b/cfml.parsing/src/test/resources/tag/tests/parsing/cfqueryparam.expected.txt
@@ -1,0 +1,18 @@
+START:cfquery
+  =========TAG=================
+  <cfquery>
+	select <cfqueryparam> from table where <cfqueryparam> =<cfqueryparam>
+</cfquery>
+  START:cfqueryparam
+    =========TAG=================
+    <cfqueryparam>
+  END:cfqueryparam
+  START:cfqueryparam
+    =========TAG=================
+    <cfqueryparam>
+  END:cfqueryparam
+  START:cfqueryparam
+    =========TAG=================
+    <cfqueryparam>
+  END:cfqueryparam
+END:cfquery

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.cfparser</groupId>
 	<artifactId>cfparser</artifactId>
-	<version>2.4.6</version>
+	<version>2.4.9</version>
 	<packaging>pom</packaging>
 
 	<name>coldfusion-parser</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.cfparser</groupId>
 	<artifactId>cfparser</artifactId>
-	<version>2.4.9</version>
+	<version>2.4.10-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>coldfusion-parser</name>


### PR DESCRIPTION
So besides getting develop up to date with master, this removes the extra loggers, and bunps the version up to 2.4.10-SNAPSHOT.

I figured I'd see what the thoughts were on doing this before I merged it in.  Running `mvn clean verify` works fine.  FWIW, I went with slf4j-simple, but we could pick one of the others if we want... I just don't think we need 3. :-)

Oh yeah, this also gives cfml.dictionary its own version number, since we should really only bump it if it changes I reckon, and it's one less thing to update if we don't have to.