### PR TITLE
Change to openjdk8 (instead of oraclejdk8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
oraclejdk8 is not supported on the newer Ubuntu systems (either xenial or bionic) that Travis is using now. Use the openjdk8 package instead.